### PR TITLE
cleaned up some log calls, added 'properties.' to model references

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -38,7 +38,7 @@ export function converter (inFile, outFile, logger) {
         .then((legacyViewType) => {
           switch (legacyViewType) {
             case 'uis1':
-            case 'uis1-domain-type': 
+            case 'uis1-domain-type':
               return convertUis1(legacyView, outFile, logger)
             case 'bv1':
               return convertBv1(legacyView, outFile, logger)
@@ -92,13 +92,11 @@ export function convertAction (inFile, outFile, options) {
   }
   converter(inFile, outFile, logger)
   watch(inFile, (eventType, filename) => {
-    convert(inFile, outFile, logger)
+    converter(inFile, outFile, logger)
   }, options.watching)
-
 }
 
 export function startBunsen (commander, processHandle, convertHandler, validateHandler, version) {
-
   commander
     .version(version)
 
@@ -124,7 +122,6 @@ export function startBunsen (commander, processHandle, convertHandler, validateH
   commander.parse(processHandle.argv)
   return commander
 }
-
 
 startBunsen(
   commander,

--- a/cli/index.js
+++ b/cli/index.js
@@ -38,6 +38,7 @@ export function converter (inFile, outFile, logger) {
         .then((legacyViewType) => {
           switch (legacyViewType) {
             case 'uis1':
+            case 'uis1-domain-type': 
               return convertUis1(legacyView, outFile, logger)
             case 'bv1':
               return convertBv1(legacyView, outFile, logger)

--- a/cli/index.js
+++ b/cli/index.js
@@ -39,16 +39,14 @@ export function converter (inFile, outFile, logger) {
           switch (legacyViewType) {
             case 'uis1':
               return convertUis1(legacyView, outFile, logger)
-              break;
             case 'bv1':
-              console.log(convertBv1(legacyView, outFile, logger))
               return convertBv1(legacyView, outFile, logger)
-          } 
+          }
         })
     })
     .then((uis2View) => {
       return fsp.writeFile(outFile, JSON.stringify(uis2View, null, 2))
-    })      
+    })
     .then((result) => {
       logger.log(JSON.stringify(result, null, 2))
       logger.success(fillString('conversion.onConverted', [inFile, outFile.green]))
@@ -58,7 +56,6 @@ export function converter (inFile, outFile, logger) {
       logger.error(error)
       logger.error(`${inFile} failed to convert`)
     })
-  logger.print(fillString('conversion.onConverting', [inFile.cyan]))
 }
 
 export function validator (inFile, optionalFile, logger) {
@@ -103,7 +100,7 @@ export function startBunsen (commander, processHandle, convertHandler, validateH
 
   commander
     .version(version)
-  
+
   commander
     .command('convert')
     .description('convert old view formats into UI Schema 2')

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "author": "Chris Stoll",
   "license": "MIT",
   "dependencies": {
-    "bunsen-core": "0.11.2",
+    "bunsen-core": "0.12.0",
     "colors": "^1.1.2",
     "commander": "^2.9.0",
     "fs-promise": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint-plugin-promise": "^2.0.1",
     "eslint-plugin-standard": "^2.0.0",
     "istanbul": "^0.4.3",
-    "mocha": "^2.5.3",
+    "mocha": "^3.0.2",
     "npm-watch": "^0.1.5",
     "sinon": "^1.17.4"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build-lib": "babel src -d lib --presets es2015 --plugins add-module-exports",
     "build-cli": "babel cli -d bin --presets es2015 --plugins add-module-exports",
     "build": "npm run build-lib && npm run build-cli",
-    "lint": "eslint *.js src bin tests",
+    "lint": "eslint *.js src cli tests",
     "test": "npm run lint && npm run utest",
     "utest": "npm run build && istanbul cover _mocha -- tests"
   },

--- a/src/converter-uis1.js
+++ b/src/converter-uis1.js
@@ -24,12 +24,7 @@ export function wrapSchema (uis2) {
   return Promise.resolve({
     type: 'form',
     version: '2.0',
-    cells: [
-      {
-        classNames: uis2.classNames,
-        children: uis2.children
-      }
-    ]
+    cells: uis2.children
   })
 }
 
@@ -37,7 +32,15 @@ export function convertSchema (ui1, logger) {
   const newObj = {}
   logger.log('converting...')
   return convertClassName(ui1, newObj, logger).then((ui2) => {
-    return convertFieldGroups(ui1, ui2, logger)
+    const key = _.keys(ui1)[0]
+    if (ui1[key].fieldGroups) {
+      return convertFieldGroups(ui1, ui2, logger)
+    }
+    if (ui1[key].fields) {
+      logger.log('found fields instead of fieldgroups')
+      ui2.children = convertFields(ui1[key].fields, logger)
+      return Promise.resolve(ui2)
+    }
   })
 }
 
@@ -115,4 +118,3 @@ export function convertObjectArray (field, logger) {
   }
   return result
 }
-

--- a/src/converter-uis1.js
+++ b/src/converter-uis1.js
@@ -11,6 +11,7 @@ export function convert (uis1, outfile, logger) {
       return wrapSchema(uis2, logger)
     })
     .then((uis2) => {
+      logger.log(JSON.stringify(uis2, null, 2))
       logger.log('attempting to validate view')
       return validateView(uis2, logger)
         .then((result) => {
@@ -70,10 +71,10 @@ export function convertFieldsets (fieldsets, logger) {
   return _.map(fieldsets, (fieldset, key) => {
     logger.log('key: ' + key)
     return {
-      model: key.split('_').join(''),
+      model: `properties.${key.split('_').join('')}`,
       label: fieldset.label || '',
       description: fieldset.description || fieldset.help || '',
-      collapsible: fieldset['switch'] || true,
+      collapsible: !!fieldset['switch'] || true,
       children: convertFields(fieldset.fields, logger)
     }
   })
@@ -83,13 +84,12 @@ export function convertFields (fields, logger) {
   logger.log('converting fields...')
   return _.map(fields, (field, key) => {
     const newField = {
-      model: key,
+      model: `properties.${key}`,
       label: field.label || '',
       description: field.description || field.help || ''
     }
     if (field.type === 'objectarray') {
       newField.arrayOptions = convertObjectArray(field, logger)
-      logger.log(newField.arrayOptions)
     }
     const placeholder = field.placeholder || field.prompt
     if (placeholder) _.extend(newField, {placeholder})
@@ -109,7 +109,7 @@ export function convertObjectArray (field, logger) {
   if (field.order) {
     result.itemCell = {
       children: _.map(field.order.split(','), (prop) => {
-        return { model: prop }
+        return { model: `properties.${prop}` }
       })
     }
   }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -39,7 +39,7 @@ export function convertInstructions (field, logger) {
 
 export function getInstructorValue (inst, field) {
   let value = '${' + inst.value + '}'
-  if (inst.value.split('\'').length === 3) {
+  if (inst.value && inst.value.split && inst.value.split('\'').length === 3) {
     value = inst.value.split('\'')[1]
   }
   if (inst.value === 'instructor') {
@@ -53,16 +53,17 @@ export function getInstructorValue (inst, field) {
 
 export function setModelType (options, field) {
   if (field.resourceType) {
+    if (field.resourceType.split('.').length === 3) {
+      options.modelType = 'resource'
+      return
+    }
     options.modelType = field.resourceType
-  }
-  if (field.resourceType.split('.').length === 3) {
-    options.modelType = 'resource'
   }
 }
 
 export function setQuery (options, field, logger) {
   const query = {}
-  if (field.resourceType.split('.').length === 3) {
+  if (field.resourceType && field.resourceType.split('.').length === 3) {
     _.extend(query, {resourceTypeId: field.resourceType})
   }
   if (field.instructions) {
@@ -102,7 +103,7 @@ export function setRendererOptions (renderer, uis1Field, logger) {
   setModelType(options, uis1Field)
   smartSet(options, 'valueAttribute', uis1Field)
   smartSet(options, 'labelAttribute', uis1Field)
-  setQuery(options, uis1Field)
+  setQuery(options, uis1Field, logger)
   if (!_.isEmpty(options)) {
     renderer.options = options
   }

--- a/src/transforms.js
+++ b/src/transforms.js
@@ -14,7 +14,7 @@ export function transformObject (uis1Transform) {
   const keywords = ['value', 'id', 'label']
   return {
     object: _.reduce(uis1Transform, (result, value, key) => {
-      if (value.split('\'').length === 3) {
+      if (value && value.split && value.split('\'').length === 3) {
         value = value.split('\'')[1]
       }
       if (_.indexOf(keywords, value) !== -1) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -32,7 +32,7 @@ export function writeFile (outfile, data) {
   })
 }
 
-export function getDefaultOutputPath (inputPath) {
+export function getDefaultOutputPath (inputPath = '') {
   return `${inputPath.split('.')[0]}-uis2.json`
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -43,5 +43,8 @@ export function getLegacyViewType (view) {
   if (_.keys(view)[0] && _.keys(view)[0].split('.').length === 3) {
     return Promise.resolve('uis1')
   }
+  if (_.keys(view)[0] && _.keys(view)[0].split(':').length > 3) {
+    return Promise.resolve('uis1-domain-type')
+  }
   return Promise.reject(strings.strings.conversion.errors.noViewType)
 }

--- a/tests/cli-spec.js
+++ b/tests/cli-spec.js
@@ -93,13 +93,6 @@ describe('the cli', function () {
     expect(cmdr.args[2].watch).to.be.ok
   })
 
-  it('has options set', function () {
-    const processMock = {argv: ['', '', 'validate', 'somearg', 'someotherarg', '-v', '-w']}
-    const cmdr = cli.startBunsen(commander, processMock, cli.validateAction, cli.convertAction, logger, '1.1.1')
-    expect(cmdr.args[2].verbose).to.be.ok
-    expect(cmdr.args[2].watch).to.be.ok
-  })
-
   it('.converter() works', function () {
     console.log(cli.converter)
     utils.parseJSON.returns(Promise.resolve('great'))
@@ -121,4 +114,3 @@ describe('the cli', function () {
     expect(cli.validator.called).not.to.be.ok
   })
 })
-

--- a/tests/cli-spec.js
+++ b/tests/cli-spec.js
@@ -90,7 +90,6 @@ describe('the cli', function () {
     const processMock = {argv: ['', '', 'validate', 'somearg', 'someotherarg', '-v', '-w']}
     const cmdr = cli.startBunsen(commander, processMock, cli.validateAction, cli.convertAction, logger, '1.1.1')
     expect(cmdr.args[2].verbose).to.be.ok
-    expect(cmdr.args[2].watch).to.be.ok
   })
 
   it('.converter() works', function () {

--- a/tests/converter-uis1-spec.js
+++ b/tests/converter-uis1-spec.js
@@ -83,7 +83,7 @@ describe('the converter', function () {
     const expected = [{
       label: 'test-field',
       description: '',
-      model: 'field',
+      model: 'properties.field',
       transforms: {
         write: [
           {
@@ -111,13 +111,13 @@ describe('the converter', function () {
     const result = converter.convertFields(data.fields, logger)
     const expected = [
       {
-        model: 'fieldA',
+        model: 'properties.fieldA',
         label: 'somelabel',
         description: 'help',
         placeholder: 'test-prompt'
       },
       {
-        model: 'fieldB',
+        model: 'properties.fieldB',
         label: 'someotherlabel',
         description: 'description',
         placeholder: 'test-placeholder'
@@ -132,15 +132,15 @@ describe('the converter', function () {
         {
           label: 'somename',
           children: [
-            { model: 'somefield', description: '', label: '' },
-            { model: 'someotherfield', description: '', label: '' },
+            { model: 'properties.somefield', description: '', label: '' },
+            { model: 'properties.someotherfield', description: '', label: '' },
             {
-              model: 'somefieldset',
+              model: 'properties.somefieldset',
               collapsible: true,
               description: '',
               label: '',
               children: [
-                { model: 'somefieldset_field', description: '', label: '' }
+                { model: 'properties.somefieldset_field', description: '', label: '' }
               ]
             }
           ]
@@ -156,18 +156,18 @@ describe('the converter', function () {
   it('.convertFieldsets() converts fieldsets', function () {
     const expected = [
       {
-        model: 'fieldSetA',
+        model: 'properties.fieldSetA',
         label: 'Alabel',
         description: 'Ahelp',
         collapsible: true,
-        children: [ {model: 'cellA', label: 'cellAlabel', description: ''} ]
+        children: [ {model: 'properties.cellA', label: 'cellAlabel', description: ''} ]
       },
       {
-        model: 'fieldSetB',
+        model: 'properties.fieldSetB',
         label: 'Blabel',
         description: 'Bdescription',
         collapsible: true,
-        children: [ {model: 'cellB', label: 'cellBlabel', description: ''} ]
+        children: [ {model: 'properties.cellB', label: 'cellBlabel', description: ''} ]
       }
     ]
     const result = converter.convertFieldsets(data.fieldsets, logger)
@@ -187,10 +187,10 @@ describe('the converter', function () {
       compact: true,
       itemCell: {
         children: [
-          { model: 'field1' },
-          { model: 'field2' },
-          { model: 'field3' },
-          { model: 'field4' }
+          { model: 'properties.field1' },
+          { model: 'properties.field2' },
+          { model: 'properties.field3' },
+          { model: 'properties.field4' }
         ]
       },
       showLabel: false,
@@ -208,4 +208,3 @@ describe('the converter', function () {
       })
   })
 })
-

--- a/tests/converter-uis1-spec.js
+++ b/tests/converter-uis1-spec.js
@@ -42,7 +42,7 @@ describe('the converter', function () {
     })
 
     it('converts the schema', function () {
-      return converter.convert({foo: 'bar'}, 'someotherfile', logger)
+      return converter.convert({foo: {fields: []}}, 'someotherfile', logger)
         .then((result) => {
           expect(validateViewSpy.called).to.be.ok
         })
@@ -53,12 +53,7 @@ describe('the converter', function () {
     const expected = {
       type: 'form',
       version: '2.0',
-      cells: [
-        {
-          classNames: '',
-          children: []
-        }
-      ]
+      cells: []
     }
     return converter.wrapSchema({classNames: '', children: []})
       .then((result) => {

--- a/tests/fixtures/data.js
+++ b/tests/fixtures/data.js
@@ -48,15 +48,15 @@ module.exports = {
       {
         label: 'somename',
         children: [
-          { model: 'somefield', description: '', label: '' },
-          { model: 'someotherfield', description: '', label: '' },
+          { model: 'properties.somefield', description: '', label: '' },
+          { model: 'properties.someotherfield', description: '', label: '' },
           {
-            model: 'somefieldset',
+            model: 'properties.somefieldset',
             collapsible: true,
             description: '',
             label: '',
             children: [
-              { model: 'somefieldset_field', description: '', label: '' }
+              { model: 'properties.somefieldset_field', description: '', label: '' }
             ]
           }
         ]


### PR DESCRIPTION
#PATCH#

### CHANGELOG
- fixed bug where `properties.` was not being prepended to model references
- cleaned up some `console.` calls
- fixed root-level nesting, now uses root-level cells so the view will produce tabs
- updated bunsen-core to 0.12.0
- added support for domain-type UIS1s